### PR TITLE
ux: display a clean error message in case idefix itself errors out in idfx run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - UX: add default values for the `directory` positional argument in `idfx clean` and `idfx run`
-
+- UX: display a clean error message in case idefix itself errors out in `idfx run`
 
 ## [0.3.3] - 2021-05-18
 

--- a/idefix_cli/commands/_run.py
+++ b/idefix_cli/commands/_run.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from subprocess import check_call
+from subprocess import call
 from typing import Optional, Union
 from uuid import uuid4
 
@@ -108,5 +108,7 @@ def run(
             print(f"Running patched inifile {pinifile}")
 
     with pushd(d):
-        check_call(["./idefix", "-i", str(pinifile.name)])
-    return 0
+        ret = call(["./idefix", "-i", str(pinifile.name)])
+        if ret != 0:
+            print_err("idefix terminated with an error.")
+        return ret


### PR DESCRIPTION
fix #47 