### PR TITLE
ENH: when compiling idefix, always use CPUs in powers of 2 (up to 8), and strictly less than the available number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- ENH: when compiling idefix, always use CPUs in powers of 2 (up to 8), and
+  strictly less than the available number. Previously we used `min(8, count//2)`
+
 ## [0.19.3] - 2022-06-16
 
 BUG: fix pattern matching in idfx run again

--- a/idefix_cli/_commons.py
+++ b/idefix_cli/_commons.py
@@ -122,8 +122,8 @@ def print_subcommand(cmd: list[str], *, loc: Path | None = None) -> None:
 
 @requires_idefix()
 def _make(directory) -> int:
-    ncpus = str(min(8, cpu_count() // 2))
-    cmd = ["make", "-j", ncpus]
+    ncpus = 2 ** min(3, cpu_count().bit_length())
+    cmd = ["make", "-j", str(ncpus)]
     print_subcommand(cmd, loc=Path(directory))
     try:
         with chdir(directory):


### PR DESCRIPTION
fix #140