### PR TITLE
DEPR: deprecate [idefix_cli] configuration section in favor of command specific ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - DOC: clarify and fix a couple example in the README
 - ENH: resolve dir path (improve error message in idfx run)
+- DEPR: deprecate `[idefix_cli]` configuration section in favor of command specific ones (like `[idfx conf]`)
 
 ## [0.20.1] - 2022-06-23
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ A prefered conf system can also be stored as
 ```ini
 # idefix.cfg
 
-[idefix_cli]
-conf_system = python  # use configure.py
+[idfx conf]
+engine = python  # use configure.py
 # or
-conf_system = cmake
+engine = cmake
 ```
 though this is mostly useful for testing purposes. In general `idfx conf`
 automatically determines which configuration system to use based on

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,9 +4,7 @@ import pytest
 from packaging.version import Version
 from pytest import assume
 
-from idefix_cli._commands.conf import is_cmake_required
 from idefix_cli._commands.conf import substitute_cmake_args
-from idefix_cli._commons import get_user_config_file
 from idefix_cli._main import main
 
 
@@ -19,25 +17,6 @@ def isolated_conf_dir(tmp_path, monkeypatch):
     return conf_dir
 
 
-@pytest.mark.parametrize("mode", ["local", "global"])
-def test_require_cmake(mode, isolated_conf_dir):
-    assert get_user_config_file() is None
-    assert not is_cmake_required()
-
-    cfg = {"local": "idefix.cfg", "global": str(isolated_conf_dir / "idefix.cfg")}[mode]
-    with open(cfg, "w") as fh:
-        fh.write("[some valid section]\nparam=value\n")
-    assert not is_cmake_required()
-
-    with open(cfg, "a") as fh:
-        fh.write("[idefix_cli]\nconf_system=cmake\n")
-    assert is_cmake_required()
-
-    with open(cfg, "a") as fh:
-        fh.write("[compilation]\nCPU=BDW\n")
-    assert is_cmake_required()
-
-
 def test_setup_requiring_cmake_in_bad_env(capsys, tmp_path, monkeypatch):
     tmp_idefix_dir = tmp_path / "idefix"
     os.makedirs(tmp_idefix_dir / ".git")
@@ -46,7 +25,7 @@ def test_setup_requiring_cmake_in_bad_env(capsys, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     usr_config = tmp_path / "idefix.cfg"
     with open(usr_config, "w") as fh:
-        fh.write("[idefix_cli]\nconf_system=cmake\n")
+        fh.write("[idfx conf]\nengine=cmake\n")
 
     # not going to test every possible case, but we want to make sure that
     # the requirements are not met for this test, so we mock (almost)


### PR DESCRIPTION
This paves the way to a new [idfx clone] section