### PR TITLE
DOC: bootstrap website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,12 @@ jobs:
     name: type check
 
     concurrency:
-      group: ${{ github.ref }}-dev
+      group: ${{ github.ref }}-type
       cancel-in-progress: true
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Set up Python
+    - name: Setup Python
       uses: actions/setup-python@v4
       with:
         # Match minimal supported Python version
@@ -89,3 +86,31 @@ jobs:
 
     - name: Run mypy
       run: mypy idefix_cli
+
+
+  docs:
+    runs-on: ubuntu-latest
+    name: docs
+
+    concurrency:
+      group: ${{ github.ref }}-docs
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Setup env
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r docs/requirements.txt
+    - name: Build
+      run: |
+        python -m mkdocs build
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: site
+        path: site

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,6 @@ repos:
   - id: pyupgrade
     args: [--py38-plus]
 
-- repo: https://github.com/Lucas-C/pre-commit-hooks-nodejs
-  rev: v1.1.2
-  hooks:
-  - id: markdown-toc
-
 - repo: https://github.com/PyCQA/autoflake
   rev: v1.6.1
   hooks:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: '3.8'
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,3 @@
+{%
+   include-markdown "../CHANGELOG.md"
+%}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,276 @@
+
+
+# Builtin Commands
+
+
+## `idfx conf`
+
+`idfx conf` is a unified wrapper for `cmake` and the historical Python script
+`$IDEFIX_DIR/configure.py`. All arguments and flags are passed down to the
+relevant configuration system.
+
+Arguments that were originally implemented in
+`$IDEFIX_DIR/configure.py` (`-mhd`, `-mpi`, `-openmp`, `-cxx`, `-arch`, `-gpu`)
+are converted on the fly for cmake.
+
+For instance
+```shell
+$ idfx conf -mhd -mpi -gpu -arch Ampere86 -cxx g++
+```
+is equivalent to
+```
+$ cmake $IDEFIX_DIR \
+  -DIdefix_MHD=ON \
+  -DIdefix_MPI=ON \
+  -DKokkos_ENABLE_CUDA=ON \
+  -DKokkos_ARCH_AMPERE86=ON \
+  -DCMAKE_CXX_COMPILER=g++
+```
+
+`idfx conf` accepts a `--dir <path>` argument.
+```shell
+idfx conf --dir my/setup/dir
+```
+is equivalent to
+```shell
+pushd my/setup/dir && idfx conf && popd
+
+
+### Configuration
+
+Some configuration options like prefered compiler and target architecture rarely
+need to be changed on a single machine.
+
+For instance, one can select a persistent build target (say Ampere86) and custom compiler as
+```ini
+# idefix.cfg
+
+[compilation]
+GPU = Ampere86
+compiler = g++
+```
+
+A prefered configuration engine can also be stored as
+```ini
+# idefix.cfg
+
+[idfx conf]
+# use configure.py
+engine = python
+# or CMake
+engine = cmake
+```
+though this is mostly useful for testing purposes. In general `idfx conf`
+automatically determines which configuration system to use based on
+resources available. Cmake is prefered over Python when both are available.
+
+Any option passed on the command line will override its equivalent persistent
+configuration.
+
+Lastly, it is possible invoke `ccmake` instead of `cmake` by passing the
+`-i/--interactive` flag to `idfx conf`.
+
+
+## `idfx run`
+
+This command is intended as a simple assistant to continuously check soundness
+of your setup as your developing it, and run tests problems locally for
+very short periods of time.
+
+`idfx run` essentially invokes the `idefix` binary, but will also (re)compiles
+it if necessary. If source files were edited since last compilation, an
+interactive prompt will offer to recompile.
+
+Note that this command will fail if neither `idefix` or `Makefile` are found in the
+specified directory. Use `idfx conf` to generate the `Makefile`.
+
+Additional, arbitrary arguments may be passed to the `idefix` executable via this
+command.
+
+### minimal example: run a test sequentially
+
+```shell
+$ idfx run --dir $IDEFIX_DIR/test/HD/KHI
+```
+The default behaviour is to use `idefix.ini` contained in the specified directory. If you
+want to run a different one, use `-i/--inifile`
+```shell
+$ idfx run -i myconf.ini
+```
+
+Note that `idfx run` looks for the inifile relative to the cwd, and _then_ relative to
+the specified directory.
+
+### running a shorter version of a problem
+Use the `--duration` and `--time-step` arguments to run a modified version of a base
+inifile.
+
+```shell
+$ idfx run --duration 1e-4
+```
+
+Note that `--time-step` maps to Idefix's inifile `TimeIntegrator.first_dt`.
+
+Use `--one-step/--one` to run a single time step (total simulation time equates to the
+first time step).
+The length of the time step can be adjusted in combination with `--time-step`, however,
+`--one-step` is incompatible with `--duration`.
+
+```shell
+$ idfx run --one
+```
+is a shortcut for
+```shell
+$ idfx run --duration x --time-step x
+```
+where `x`, is the existing value found in the inifile. `idfx run --one` also
+optionally accepts arbitrary output format identifiers. For instance
+```shell
+$ idfx run --one dmp vtk
+```
+will run the curdir setup for one time step and output both a dmp file and a vtk file.
+
+The `--times <n>` argument can also be supplied in combination with `--one` to
+run for an arbitry number of steps. It is close to idefix's `-maxcycles`
+argument.
+
+### running in parallel
+
+`idfx run` also wraps around `mpirun -> idefix` via the `--nproc` optional argument.
+For instance
+```shell
+$ idfx run --dir mydir --nproc 2
+```
+is equivalent to
+```
+$ pushd mydir ; mpirun -n 2 ./idefix ; popd
+```
+
+## `idfx clean`
+
+Removes intermediate compilation files (`*.o`, `*.host`, `*.cuda`) as well as
+CMake cache files and directories
+
+```shell
+$ idfx clean .
+```
+This command will print a list of purgable files, and will not remove anything
+without confirmation.
+
+To also remove `Makefile`, `idefix` executables, use the `--all` flag
+```shell
+$ idfx clean . --all
+```
+
+Use the `--dry-run/--dry` flag to skip the prompt and only display the list of
+purgeable items, without actually deleting anything.
+
+## `idfx clone`
+
+Clone an idefix problem directory by copying the main source files
+(`definitions.hpp`, `setup.cpp`, `idefix.ini`).
+
+```shell
+$ idfx clone $IDEFIX_DIR/test/HD/KHI/ /tmp/myKHI
+```
+
+<details>
+<summary>More</summary>
+
+Instead of making hard copies, files can be symbolically linked to instead of
+copied, with `--shallow`.
+
+Additional files may be included in the clone using the `--include` argument. They
+can be specified either by name or POSIX pattern, e.g.
+```shell
+$ idfx clone $IDEFIX_DIR/test/HD/KHI/ /tmp/myKHI --include "*.log"
+```
+
+Note that extra patterns need be escaped, else they'd be interpreted by the
+shell before they make it to `idefix_cli`.
+
+### Configuration
+
+Arbitrary patterns can also be stored in the configuration file. For example
+```ini
+# idefix.cfg
+
+[idfx clone]
+include = *py README.*
+```
+Note that the `--include` argument can be combined with `idefix.cfg`.
+
+</details>
+
+## `idfx stamp`
+
+Prints key data for reproduction and development to stdout.
+
+```shell
+$ idfx stamp
+v0.5
+daff799bb64b0993f058f50779873d594376d5bf
+lesurg
+f-dahu
+Sat Jan 16 16:15:28 2021
+```
+<details>
+<summary>More</summary>
+
+This command is roughly equivalent to
+```shell
+$ cd $IDEFIX_DIR \
+  && git describe --tags \
+  && cd - > /dev/null \
+  && date \
+  && hostname \
+  && echo $USER
+```
+Additionnally, one can get the underlying data in json-serializable format
+```shell
+$ idfx stamp --json
+{
+  "tag": "v0.5",
+  "sha": "daff799bb64b0993f058f50779873d594376d5bf",
+  "user": "glesur",
+  "host": "f-dahu",
+  "date": "Sat Jan 16 16:15:54 2021"
+}
+```
+
+This is helpful to quickly store important metadata next to one's datafiles. The git tag
+may be of critical value for reproductability, especially when bugs in Idefix are found
+after simulations are run, like so
+
+```shell
+$ idfx stamp --json > metadata.json
+```
+</details>
+
+
+## `idfx read`
+
+Read an Idefix inifile and print the resulting dictionnary to stdout in a json parsable
+format. This is useful to inspect inifiles programatically in combination with tools like
+[jq](https://stedolan.github.io/jq/)
+```shell
+$ idfx read $IDEFIX_DIR/test/HD/KHI/idefix.ini | jq '.Output.vtk' --compact-output
+[0.01,-1,"single_file"]
+```
+
+By default, the ouptut of `idfx read` is flat. Optionnaly, you can use `--indent <N>` to
+improve human-readability.
+
+## `idfx write`
+
+Conversely, `idfx write` converts from json formatted strings to Idefix inifile format
+
+```shell
+$ idfx write save.ini $(cat save.json)
+```
+
+### arbitrary patching
+`idfx read` and `idfx write` methods can be combined with `jq` to arbitrarily patch an inifile
+```shell
+$ idfx read test/HD/KHI/idefix.ini | jq .TimeIntegrator.CFL=1e6 | idfx write idefix_patched.ini
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,24 @@
+
+## Contributing and testing
+
+We use the [pre-commit](https://pre-commit.com) framework to automatically lint for code
+style and common pitfals.
+
+Before you commit to your local copy of the repo, please run this from the top level
+```shell
+$ python -m pip install -u -e .
+$ python -m pip install -r test_requirements.txt
+```
+
+It is also recommended to install `pre-commit` on your machine and then run,
+from the top level
+```shell
+$ pre-commit install
+```
+
+We use the [pytest](https://docs.pytest.org/en/latest/) framework to test `idfx`'s
+internal components. The test suite can be run from the top level with a simple `pytest`
+invocation.
+```shell
+$ pytest
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,4 @@
-[![PyPI](https://img.shields.io/pypi/v/idefix_cli)](https://pypi.org/project/idefix-cli/)
-![PyPI](https://img.shields.io/badge/requires-Python%20≥%203.8-blue?logo=python&logoColor=white)
-[![Documentation Status](https://readthedocs.org/projects/idefix-cli/badge/?version=latest)](https://idefix-cli.readthedocs.io/en/latest/?badge=latest)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/neutrinoceros/idefix_cli/main.svg)](https://results.pre-commit.ci/badge/github/neutrinoceros/idefix_cli/main.svg)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
-# `idefix_cli`
+# idefix_cli
 
 `idefix_cli` is command line framework to facilitate working with
 [Idefix](https://gricad-gitlab.univ-grenoble-alpes.fr/lesurg/idefix-public),
@@ -35,7 +29,7 @@ set at runtime.
 
 ## Get help
 
-Get a complete description of available commands with
+The following contains usage examples. Get a complete description of available options with
 ```shell
 $ idfx --help
 ```
@@ -44,4 +38,13 @@ Likewise, get help for each command therein as, for instance
 $ idfx run --help
 ```
 
-For more, read [the documentation !](https://idefix-cli.readthedocs.io/en/latest/?badge=latest)
+## Configuration
+
+`idfx_cli` supports persistent configuration. It follows the last version of
+`$IDEFIX_DIR/configure.py` and looks for options stored in
+`$HOME/.config/idefix.cfg`.
+
+Command specific options are stored in corresponding sections
+, e.g., `idfx conf` looks into the `[idfx conf]` section.
+
+More detail is given about each option in [Builtin Commands](commands.md).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,54 @@
+# Define commands
+
+
+## Configuration
+🚧 This section is under construction 🚧
+
+https://github.com/neutrinoceros/idefix_cli/issues/177
+
+## A basic example
+
+Here's simple example illustrating all the requirements for a plugin file.
+Say that we want to define a `idfx hello` command
+```python
+# hello.py
+"Say hello n times"
+
+from idefix_cli.lib import print_error
+
+
+def add_arguments(parser) -> None:
+    # Define arbitrary arguments
+    # parser is a argparse.ArgumentParser object
+    # https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser
+    #
+    # this function is required, its signature is mandatory, but the body can be left empty
+    parser.add_argument(
+        "nrepeat",
+        type=int,
+        help="number of times to say 'hello'. Must be (>=1)",
+    )
+
+
+def command(nrepeat:int) -> int:
+    # Define the actual script
+    #
+    # this function is required and its return type must be int
+    # (return 0 is all goes well, otherwise return 1)
+    # the arguments must match those defined in add_arguments
+    if nrepeat <= 0:
+        # illustrate how to deal with exceptions
+        print_error(f"Cannot greet less than 1 time !")
+        return 1
+
+    print(nrepeat * "Hello " + "!")
+    return 0
+```
+
+Note that the name of the file (here `hello.py`) defines the name of the command (`idfx hello`).
+The module-level docstring is also required and serves as the description of the command when `idfx --help` is invoked.
+
+## Public API
+🚧 This section is under construction 🚧
+
+https://github.com/neutrinoceros/idefix_cli/issues/193

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.4.2
+mkdocs-material==8.5.10

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.4.2
 mkdocs-material==8.5.10
+mkdocs-include-markdown-plugin==4.0.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: idefix_cli
+theme:
+  name: material
+  palette:
+  - scheme: default
+    primary: indigo
+    accent: indigo
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+  - scheme: slate
+    primary: indigo
+    accent: indigo
+    toggle:
+      icon: material/brightness-4
+      name: Switch to light mode
+
+markdown_extensions:
+- admonition
+#  - pymdownx.details
+#  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,3 +19,9 @@ markdown_extensions:
 - admonition
 #  - pymdownx.details
 #  - pymdownx.superfences
+
+- pymdownx.highlight:
+    anchor_linenums: true
+- pymdownx.inlinehilite
+- pymdownx.snippets
+- pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,9 +19,11 @@ markdown_extensions:
 - admonition
 #  - pymdownx.details
 #  - pymdownx.superfences
-
 - pymdownx.highlight:
     anchor_linenums: true
 - pymdownx.inlinehilite
 - pymdownx.snippets
 - pymdownx.superfences
+
+plugins:
+- include-markdown


### PR DESCRIPTION
Deploying with readthedocs.io

The branch can be previewed at:
https://idefix-cli.readthedocs.io/en/site/

TODO:
- [x] organise documentation (not a single-page layout)
- [x] replace README's content with a badge linking to the website
- [x] include CHANGELOG.md somehow
- [x] add syntax highlighting for code snippets
- [x] add doc build to CI
