### PR TITLE
PERF: avoid unnecessary json serialization in idfx digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ENH: add `-o/--output` argument to `idfx digest`
 - PERF: faster type casting in `idfx digest``
-
+- PERF: avoid unnecessary json serialization in `idfx digest`
 
 ## [2.4.0] - 2023-07-29
 

--- a/src/idefix_cli/_commands/digest.py
+++ b/src/idefix_cli/_commands/digest.py
@@ -1,6 +1,5 @@
 """agregate performance data from log files as json"""
 
-import json
 import re
 import sys
 from argparse import ArgumentParser
@@ -28,17 +27,32 @@ def _parse_token(raw_data: str):
     return sdata
 
 
-def _log_to_json(log: list[str]):
+def _log_to_data(log: list[str]):
     columns: dict[str, list[Any]] = {name.strip(): [] for name in log[0].split("|")}
     types = [type(_parse_token(t)) for t in log[1].split("|")]
-    tokenized_log = [
-        [_type(t) for t, _type in zip(line.replace("N/A", "nan").split("|"), types)]
-        for line in log[1:]
-    ]
-
+    tokenized_log = [line.replace("N/A", "NaN").split("|") for line in log[1:]]
     for i, name in enumerate(columns.keys()):
         columns[name] = [L[i] for L in tokenized_log]
-    return columns
+    return columns, types
+
+
+def _data_to_json(header: str, data: dict[str, list[str]], types: list[type]) -> str:
+    res: list[str] = ['"%s": {' % header]
+    ncolumns = len(types)
+    for icol, ((name, record), t) in enumerate(zip(data.items(), types)):
+        if icol < ncolumns - 1:
+            trail = ","
+        else:
+            trail = ""
+        line = '"%s":' % name
+        if t is str:
+            line += '  ["' + ', "'.join(record) + '"]' + trail
+        else:
+            line += "  [" + ", ".join(record) + "]" + trail
+        res.append(line)
+
+    res.append("}")
+    return "\n".join(res)
 
 
 def add_arguments(parser: ArgumentParser) -> None:
@@ -102,11 +116,12 @@ def command(
             if c[0] != header:  # pragma: no cover
                 print_err(f"header mismatch from {p} and {log_files[0]}")
 
-    final_result = {}
+    final_result: list[str] = []
     for p, d in zip(log_files, data):
-        final_result.update({str(p.relative_to(dir)): _log_to_json(d)})
+        columns, types = _log_to_data(d)
+        final_result.append(_data_to_json(p.name, columns, types))
 
-    _json = json.dumps(final_result, indent=2)
+    _json = "{\n" + ",\n".join(final_result) + "\n}"
     if isinstance(output, str):
         with open(output, "w") as fh:
             print(_json, file=fh)


### PR DESCRIPTION
This implementation is roughly x2 as compared to the main branch, at the cost of a less pretty output.