### PR TITLE
ENH: add short version -i for idfx digest --input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API: remove `idfx stamp` command, drop dependency on GitPython
 - DEP: bump minimal and pinned `inifix` from 3.0.0 to 4.2.2
 - DEPR: rename print_err to print_error, deprecate old name
+- ENH: add short version `-i` for `idfx digest --input ...`
 
 ## [3.2.1] - 2023-09-06
 

--- a/src/idefix_cli/_commands/digest.py
+++ b/src/idefix_cli/_commands/digest.py
@@ -62,6 +62,7 @@ def add_arguments(parser: ArgumentParser) -> None:
     ),
     select_group = parser.add_mutually_exclusive_group()
     select_group.add_argument(
+        "-i",
         "--input",
         dest="input_",
         nargs="*",


### PR DESCRIPTION
This was initially contributed by @volodia99 in #321 but I factored it out because it was untested. It was then pointed out to me that `-o` wasn't tested either, so I've changed my mind and prefer having symmetry in the API.