### PR TITLE
BUG: fix a crash in `idfx run` where a Python exception would be raised instead of an error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- BUG: fix a crash in `idfx run` where a Python exception would be raised
+  instead of an error message
+
 ## [6.0.0] - 2024-12-05
 
 - DEP: drop `[isolated]` extra (external tooling should handle dependency pinning)

--- a/src/idefix_cli/_commands/run.py
+++ b/src/idefix_cli/_commands/run.py
@@ -359,7 +359,7 @@ def command(
     except ValueError:
         print_warning(
             f"Expected [idfx run].recompile to be any of {[str(_) for _ in RebuildMode]}"
-            f"Got {rebuild_mode} from {get_config_file()}\n"
+            f"Got {rebuild_mode_str!r} from {get_config_file()}\n"
         )
         print_warning("Falling back to 'prompt' mode.")
         rebuild_mode = RebuildMode.PROMPT


### PR DESCRIPTION
This bug was detected by pyright