### PR TITLE
TYP: improve type checking with pyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,15 @@ jobs:
         python-version:
         - '3.10'
         - '3.13'
+        typechecker:
+        - mypy
+        - pyright
 
     runs-on: ubuntu-latest
     name: type check
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}-typecheck
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}-${{ matrix.typechecker }}-typecheck
       cancel-in-progress: true
 
     steps:
@@ -93,8 +96,8 @@ jobs:
     - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
     - name: Build
       run: uv sync -p ${{ matrix.python-version }} --group typecheck --no-editable
-    - name: Run mypy
-      run: uv run mypy src/idefix_cli
+    - name: Typecheck
+      run: uv run ${{ matrix.typechecker }} src
 
   docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DEP: require inifix 5.1.0 or newer, fix newly detected type-checking errors
 - BUG: fix a crash in `idfx run` where a Python exception would be raised
   instead of an error message
+- TYP: improve typechecking with pyright
 
 ## [6.0.0] - 2024-12-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ covcheck = [
 ]
 typecheck = [
     "mypy>=1.11.2",
+    "pyright>=1.1.390",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/src/idefix_cli/_commands/clean.py
+++ b/src/idefix_cli/_commands/clean.py
@@ -70,7 +70,7 @@ def command(
 ) -> int:
     origin = os.path.abspath(os.curdir)
     with chdir(directory):
-        patterns = bpatterns | kokkos_files | cmake_files | GENERATED_DIRS
+        patterns = set(bpatterns | kokkos_files | cmake_files | GENERATED_DIRS)
         if clean_all:
             patterns |= gpatterns
 

--- a/src/idefix_cli/_commands/clone.py
+++ b/src/idefix_cli/_commands/clone.py
@@ -48,8 +48,8 @@ if sys.version_info >= (3, 12):
         def _has_trailing_sep(self) -> bool:
             return self._input.endswith(os.sep)
 
-        def resolve(self) -> Self:
-            retv = super().resolve()
+        def resolve(self, *args, **kwargs) -> Self:
+            retv = super().resolve(*args, **kwargs)
             retv._input = self._input
             return retv
 

--- a/src/idefix_cli/_commands/digest.py
+++ b/src/idefix_cli/_commands/digest.py
@@ -18,12 +18,14 @@ def _log_to_data(log: list[str]):
     for i, name in enumerate(columns.keys()):
         columns[name] = [L[i] for L in tokenized_log]
 
+    last_name = list(columns)[-1]
+
     # the very last line in a log may be polluted by a trailing warning or error
     # in practice this is only known to happen on the last column.
     # Let's sanitize this value:
 
     # rely on Python leaking variables binded by for loops
-    data = columns[name]
+    data = columns[last_name]
     last_entry = data[-1]
     if "NaN" in last_entry:
         data[-1] = "NaN"

--- a/src/idefix_cli/_commands/run.py
+++ b/src/idefix_cli/_commands/run.py
@@ -364,7 +364,7 @@ def command(
         print_warning("Falling back to 'prompt' mode.")
         rebuild_mode = RebuildMode.PROMPT
 
-    build_is_required: bool
+    build_is_required: bool = True
     if rebuild_mode is RebuildMode.ALWAYS:
         build_is_required = True
     elif rebuild_mode is RebuildMode.PROMPT:

--- a/src/idefix_cli/lib.py
+++ b/src/idefix_cli/lib.py
@@ -53,27 +53,33 @@ __all__ = [
 __all__.append("chdir")
 
 
+class _WindowsTree(StrEnum):
+    TRUNK = "|"
+    FORK = "|-"
+    ANGLE = "'-"
+    BRANCH = "-"
+
+
+class _PosixTree(StrEnum):
+    TRUNK = "│"
+    FORK = "├"
+    ANGLE = "└"
+    BRANCH = "─"
+
+
+_Tree: type[_WindowsTree | _PosixTree]
+
 if platform.system().lower().startswith("win"):
     # Windows
     env_var = "APPDATA"
     default_usr_dir = "AppData"
-
-    class _Tree(StrEnum):
-        TRUNK = "|"
-        FORK = "|-"
-        ANGLE = "'-"
-        BRANCH = "-"
+    _Tree = _WindowsTree
 
 else:
     # POSIX
     env_var = "XDG_CONFIG_HOME"
     default_usr_dir = ".config"
-
-    class _Tree(StrEnum):  # type: ignore [no-redef]
-        TRUNK = "│"
-        FORK = "├"
-        ANGLE = "└"
-        BRANCH = "─"
+    _Tree = _PosixTree
 
 
 XDG_CONFIG_HOME = os.environ.get(
@@ -343,9 +349,9 @@ def get_config_file() -> str:
     If present, the local configuration is returned, otherwise the global one is
     to be considered active, even if non-existent.
     """
-    for parent_dir in (".", XDG_CONFIG_HOME):
-        if os.path.isfile(conf_file := os.path.join(parent_dir, "idefix.cfg")):
-            break
+    local_conf_file = Path("idefix.cfg")
+    global_conf_file = Path(XDG_CONFIG_HOME, "idefix.cfg")
+    conf_file = local_conf_file if local_conf_file.is_file() else global_conf_file
     return os.path.abspath(conf_file)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,7 @@ test = [
 ]
 typecheck = [
     { name = "mypy" },
+    { name = "pyright" },
 ]
 
 [package.metadata]
@@ -132,7 +133,10 @@ test = [
     { name = "pytest", specifier = ">=7.2.1" },
     { name = "pytest-check", specifier = ">=2.1.2" },
 ]
-typecheck = [{ name = "mypy", specifier = ">=1.11.2" }]
+typecheck = [
+    { name = "mypy", specifier = ">=1.11.2" },
+    { name = "pyright", specifier = ">=1.1.390" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -199,6 +203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +227,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.390"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/42/1e0392f35dd275f9f775baf7c86407cef7f6a0d9b8e099a93e5422a7e571/pyright-1.1.390.tar.gz", hash = "sha256:aad7f160c49e0fbf8209507a15e17b781f63a86a1facb69ca877c71ef2e9538d", size = 21950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/20/3f492ca789fb17962ad23619959c7fa642082621751514296c58de3bb801/pyright-1.1.390-py3-none-any.whl", hash = "sha256:ecebfba5b6b50af7c1a44c2ba144ba2ab542c227eb49bc1f16984ff714e0e110", size = 18579 },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes a number of "possibly-unbound" variables that static type checking cannot prove will be bound, even when a human reader can show that `NameErrors` are actually impossible.