### PR TITLE
BUG: fix an incoming incompatibility with argparse (address a deprecation warning in CPython 3.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- BUG: fix an incoming incompatibility with argparse (address a deprecation
+  warning in CPython 3.14)
+
 ## [6.0.1] - 2024-12-15
 
 - DEP: require inifix 5.1.0 or newer, fix newly detected type-checking errors


### PR DESCRIPTION
`argparse.FileType` is scheduled for deprecation in 3.14, see https://docs.python.org/3.14/whatsnew/3.14.html#deprecated